### PR TITLE
Fix DE15884 (AF109 error)

### DIFF
--- a/bsd/sys/netinet/in_pcb.cc
+++ b/bsd/sys/netinet/in_pcb.cc
@@ -679,6 +679,8 @@ in_pcbladdr(struct inpcb *inp, struct in_addr *faddr, struct in_addr *laddr,
 	{
 		if (route_cache::lookup(sin, inp->inp_inc.inc_fibnum, &rte_one)) {
 			sro.ro_rt = &rte_one;
+			/* Setting RT_NORTREF prevents RO_RTFREE from attempting to free ro_rt/ */
+			sro.ro_flags |= RT_NORTREF;
 		} else {
 			sro.ro_rt = NULL;
 		}

--- a/bsd/sys/netinet/in_pcb.cc
+++ b/bsd/sys/netinet/in_pcb.cc
@@ -679,7 +679,7 @@ in_pcbladdr(struct inpcb *inp, struct in_addr *faddr, struct in_addr *laddr,
 	{
 		if (route_cache::lookup(sin, inp->inp_inc.inc_fibnum, &rte_one)) {
 			sro.ro_rt = &rte_one;
-			/* Setting RT_NORTREF prevents RO_RTFREE from attempting to free ro_rt/ */
+			/* Setting RT_NORTREF prevents RO_RTFREE from attempting to free ro_rt. */
 			sro.ro_flags |= RT_NORTREF;
 		} else {
 			sro.ro_rt = NULL;

--- a/bsd/sys/netinet/ip_output.cc
+++ b/bsd/sys/netinet/ip_output.cc
@@ -259,6 +259,8 @@ again:
 #else
 			if (route_cache::lookup(dst, inp ? inp->inp_inc.inc_fibnum : M_GETFIB(m), &rte_one)) {
 				ro->ro_rt = &rte_one;
+				/* Setting RT_NORTREF prevents RO_RTFREE from attempting to free ro_rt/ */
+				ro->ro_flags |= RT_NORTREF;
 			} else {
 				ro->ro_rt = NULL;
 			}
@@ -651,7 +653,6 @@ passout:
 			 * to avoid confusing upper layers.
 			 */
 			m->m_hdr.mh_flags &= ~(M_PROTOFLAGS);
-
 			error = (*ifp->if_output)(ifp, m,
 			    (struct bsd_sockaddr *)dst, ro);
 		} else

--- a/bsd/sys/netinet/ip_output.cc
+++ b/bsd/sys/netinet/ip_output.cc
@@ -259,7 +259,7 @@ again:
 #else
 			if (route_cache::lookup(dst, inp ? inp->inp_inc.inc_fibnum : M_GETFIB(m), &rte_one)) {
 				ro->ro_rt = &rte_one;
-				/* Setting RT_NORTREF prevents RO_RTFREE from attempting to free ro_rt/ */
+				/* Setting RT_NORTREF prevents RO_RTFREE from attempting to free ro_rt. */
 				ro->ro_flags |= RT_NORTREF;
 			} else {
 				ro->ro_rt = NULL;

--- a/bsd/sys/netinet/tcp_subr.cc
+++ b/bsd/sys/netinet/tcp_subr.cc
@@ -1689,7 +1689,7 @@ tcp_maxmtu(struct in_conninfo *inc, int *flags)
 		dst->sin_addr = inc->inc_faddr;
 		if (route_cache::lookup(dst, inc->inc_fibnum, &rte_one)) {
 			sro.ro_rt = &rte_one;
-			/* Setting RT_NORTREF prevents RO_RTFREE from attempting to free ro_rt/ */
+			/* Setting RT_NORTREF prevents RO_RTFREE from attempting to free ro_rt. */
 			sro.ro_flags |= RT_NORTREF;
 		} else {
 			sro.ro_rt = NULL;

--- a/bsd/sys/netinet/tcp_subr.cc
+++ b/bsd/sys/netinet/tcp_subr.cc
@@ -1689,6 +1689,8 @@ tcp_maxmtu(struct in_conninfo *inc, int *flags)
 		dst->sin_addr = inc->inc_faddr;
 		if (route_cache::lookup(dst, inc->inc_fibnum, &rte_one)) {
 			sro.ro_rt = &rte_one;
+			/* Setting RT_NORTREF prevents RO_RTFREE from attempting to free ro_rt/ */
+			sro.ro_flags |= RT_NORTREF;
 		} else {
 			sro.ro_rt = NULL;
 		}


### PR DESCRIPTION
Use-after-free issue of the rt_gateway object in rtentry from the route cache code. What was triggering the initial failure from agent bootup was that, for whatever reason, a DHCP renew was being sent from the agent which caused the interface to get reconfigured. This caused the rtentry associated with the meta-data service to get deleted from the stack. However, the route cache already had an entry. When the cached entry was used again, the memory pointed to by rt_gateway was already re-used by something else. 