### PR TITLE
ipv6 cleanup for submit to main osv repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ $(out)/bsd/%.o: INCLUDES += -isystem bsd/
 # for machine/
 $(out)/bsd/%.o: INCLUDES += -isystem bsd/$(arch)
 
-configuration-defines = conf-preempt conf-debug_memory conf-logger_debug
+configuration-defines = conf-preempt conf-debug_memory conf-logger_debug conf-INET6
 
 configuration = $(foreach cf,$(configuration-defines), \
                       -D$(cf:conf-%=CONF_%)=$($(cf)))
@@ -604,6 +604,7 @@ bsd += bsd/sys/netinet/cc/cc_cubic.o
 bsd += bsd/sys/netinet/cc/cc_htcp.o
 bsd += bsd/sys/netinet/cc/cc_newreno.o
 bsd += bsd/sys/netinet/arpcache.o
+ifeq ($(conf-INET6), 1)
 bsd += bsd/sys/netinet6/dest6.o
 bsd += bsd/sys/netinet6/frag6.o
 bsd += bsd/sys/netinet6/icmp6.o
@@ -627,6 +628,7 @@ bsd += bsd/sys/netinet6/raw_ip6.o
 bsd += bsd/sys/netinet6/route6.o
 bsd += bsd/sys/netinet6/scope6.o
 bsd += bsd/sys/netinet6/udp6_usrreq.o
+endif
 bsd += bsd/sys/xdr/xdr.o
 bsd += bsd/sys/xdr/xdr_array.o
 bsd += bsd/sys/xdr/xdr_mem.o

--- a/bsd/porting/netport.h
+++ b/bsd/porting/netport.h
@@ -163,7 +163,7 @@ extern int tick;
     #define INET (1)
 #endif
 
-#ifndef INET6
+#if defined(CONF_INET6) && (CONF_INET6 != 0)
     #define INET6 (1)
 #endif
 

--- a/bsd/porting/route.cc
+++ b/bsd/porting/route.cc
@@ -173,6 +173,7 @@ static struct mbuf*  osv_route_arp_rtmsg(int if_idx, int cmd, const char* ip,
 
 static int osv_sockaddr_from_string(struct bsd_sockaddr_storage *addr, const char *str)
 {
+#ifdef INET6
     struct bsd_sockaddr_in6 *sa6 = (struct bsd_sockaddr_in6*)addr;
     if (inet_pton(AF_INET6, str, (void*)&sa6->sin6_addr)) {
         sa6->sin6_len = sizeof(*sa6);
@@ -182,6 +183,7 @@ static int osv_sockaddr_from_string(struct bsd_sockaddr_storage *addr, const cha
         sa6->sin6_scope_id = 0;
         return 1;
     }
+#endif
     struct bsd_sockaddr_in *sa4 = (struct bsd_sockaddr_in*)addr;
     if (inet_pton(AF_INET, str, (void*)&sa4->sin_addr)) { 
         sa4->sin_len = sizeof(*sa4);
@@ -204,6 +206,7 @@ static int osv_sockaddr_from_prefix_len(int af, struct bsd_sockaddr_storage *add
             in_prefixlen2mask(&sa4->sin_addr, prefix_len);
         }
         return 1;
+#ifdef INET6
     case AF_INET6:
         {
             struct bsd_sockaddr_in6 *sa6 = (struct bsd_sockaddr_in6 *)addr;
@@ -215,6 +218,7 @@ static int osv_sockaddr_from_prefix_len(int af, struct bsd_sockaddr_storage *add
             in6_prefixlen2mask(&sa6->sin6_addr, prefix_len);
         }
         return 1;
+#endif
     default:
         return 0;
     }
@@ -233,7 +237,7 @@ static struct mbuf*  osv_route_rtmsg(int cmd, const char* destination,
     struct bsd_ifaddr *ifa;
     bool is_link = type == gw_type::link;
 
-    /* IPv4: Addresses */
+    /* IP: Addresses */
     struct bsd_sockaddr_storage dst;
     struct bsd_sockaddr_storage gw;
     struct bsd_sockaddr_storage mask;

--- a/bsd/sys/compat/linux/linux_socket.cc
+++ b/bsd/sys/compat/linux/linux_socket.cc
@@ -47,6 +47,7 @@
 
 
 #include <bsd/sys/net/if.h>
+#include <bsd/sys/net/if_dl.h>
 #include <bsd/sys/netinet/in.h>
 #include <bsd/sys/netinet/in_systm.h>
 #include <bsd/sys/netinet/ip.h>
@@ -336,6 +337,8 @@ linux_to_bsd_ip_sockopt(int opt)
 	return (-1);
 }
 
+#ifdef INET6
+
 static int
 linux_to_bsd_ipv6_sockopt(int opt)
 {
@@ -343,93 +346,95 @@ linux_to_bsd_ipv6_sockopt(int opt)
 	switch (opt) {
 	case LINUX_IPV6_ADDRFORM:
 		return (IPV6_ADDRFORM);
-    case LINUX_IPV6_2292PKTINFO:
-        return (IPV6_2292PKTINFO);
-    case LINUX_IPV6_2292HOPOPTS:
-        return (IPV6_2292HOPOPTS);
-    case LINUX_IPV6_2292DSTOPTS:
-        return (IPV6_2292DSTOPTS);
-    case LINUX_IPV6_2292RTHDR:
-        return (IPV6_2292RTHDR);
-    case LINUX_IPV6_2292PKTOPTIONS:
-        return (IPV6_2292PKTOPTIONS);
-    case LINUX_IPV6_CHECKSUM:
-        return (IPV6_CHECKSUM);
-    case LINUX_IPV6_2292HOPLIMIT:
-        return (IPV6_2292HOPLIMIT);
+	case LINUX_IPV6_2292PKTINFO:
+		return (IPV6_2292PKTINFO);
+	case LINUX_IPV6_2292HOPOPTS:
+		return (IPV6_2292HOPOPTS);
+	case LINUX_IPV6_2292DSTOPTS:
+		return (IPV6_2292DSTOPTS);
+	case LINUX_IPV6_2292RTHDR:
+		return (IPV6_2292RTHDR);
+	case LINUX_IPV6_2292PKTOPTIONS:
+		return (IPV6_2292PKTOPTIONS);
+	case LINUX_IPV6_CHECKSUM:
+		return (IPV6_CHECKSUM);
+	case LINUX_IPV6_2292HOPLIMIT:
+		return (IPV6_2292HOPLIMIT);
 #ifdef LINUX_IPV6_RXSRCRT
-    case LINUX_IPV6_RXSRCRT:
-        return (IPV6_RXSRCRT);
+	case LINUX_IPV6_RXSRCRT:
+		return (IPV6_RXSRCRT);
 #endif
-    case LINUX_IPV6_NEXTHOP:
-        return (IPV6_NEXTHOP);
-    case LINUX_IPV6_AUTHHDR:
-        return (IPV6_AUTHHDR);
-    case LINUX_IPV6_UNICAST_HOPS:
-        return (IPV6_UNICAST_HOPS);
-    case LINUX_IPV6_MULTICAST_IF:
-        return (IPV6_MULTICAST_IF);
-    case LINUX_IPV6_MULTICAST_HOPS:
-        return (IPV6_MULTICAST_HOPS);
-    case LINUX_IPV6_MULTICAST_LOOP:
-        return (IPV6_MULTICAST_LOOP);
+	case LINUX_IPV6_NEXTHOP:
+		return (IPV6_NEXTHOP);
+	case LINUX_IPV6_AUTHHDR:
+		return (IPV6_AUTHHDR);
+	case LINUX_IPV6_UNICAST_HOPS:
+		return (IPV6_UNICAST_HOPS);
+	case LINUX_IPV6_MULTICAST_IF:
+		return (IPV6_MULTICAST_IF);
+	case LINUX_IPV6_MULTICAST_HOPS:
+		return (IPV6_MULTICAST_HOPS);
+	case LINUX_IPV6_MULTICAST_LOOP:
+		return (IPV6_MULTICAST_LOOP);
 	case LINUX_IPV6_JOIN_GROUP:
 		return (IPV6_JOIN_GROUP);
 	case LINUX_IPV6_LEAVE_GROUP:
 		return (IPV6_LEAVE_GROUP);
-    case LINUX_IPV6_ROUTER_ALERT:
-        return (IPV6_ROUTER_ALERT);
-    case LINUX_IPV6_MTU_DISCOVER:
-        return (IPV6_MTU_DISCOVER);
+	case LINUX_IPV6_ROUTER_ALERT:
+		return (IPV6_ROUTER_ALERT);
+	case LINUX_IPV6_MTU_DISCOVER:
+		return (IPV6_MTU_DISCOVER);
 	case LINUX_IPV6_MTU:
 		return (IPV6_MTU);
-    case LINUX_IPV6_RECVERR:
-        return (IPV6_RECVERR);
-    case LINUX_IPV6_V6ONLY:
-        return (IPV6_V6ONLY);
-    case LINUX_IPV6_JOIN_ANYCAST:
-        return (IPV6_JOIN_ANYCAST);
-    case LINUX_IPV6_LEAVE_ANYCAST:
-        return (IPV6_LEAVE_ANYCAST);
-    case LINUX_IPV6_IPSEC_POLICY:
-        return (IPV6_IPSEC_POLICY);
-    case LINUX_IPV6_XFRM_POLICY:
-        return (IPV6_XFRM_POLICY);
+	case LINUX_IPV6_RECVERR:
+		return (IPV6_RECVERR);
+	case LINUX_IPV6_V6ONLY:
+		return (IPV6_V6ONLY);
+	case LINUX_IPV6_JOIN_ANYCAST:
+		return (IPV6_JOIN_ANYCAST);
+	case LINUX_IPV6_LEAVE_ANYCAST:
+		return (IPV6_LEAVE_ANYCAST);
+	case LINUX_IPV6_IPSEC_POLICY:
+		return (IPV6_IPSEC_POLICY);
+	case LINUX_IPV6_XFRM_POLICY:
+		return (IPV6_XFRM_POLICY);
 	case LINUX_IPV6_RECVPKTINFO:
 		return (IPV6_RECVPKTINFO);
-    case LINUX_IPV6_PKTINFO:
-        return (IPV6_PKTINFO);
-    case LINUX_IPV6_RECVHOPLIMIT:
-        return (IPV6_RECVHOPLIMIT);
-    case LINUX_IPV6_HOPLIMIT:
-        return (IPV6_HOPLIMIT);
-    case LINUX_IPV6_RECVHOPOPTS:
-        return (IPV6_RECVHOPOPTS);
-    case LINUX_IPV6_HOPOPTS:
-        return (IPV6_HOPOPTS);
-    case LINUX_IPV6_RTHDRDSTOPTS:
-        return (IPV6_RTHDRDSTOPTS);
-    case LINUX_IPV6_RECVRTHDR:
-        return (IPV6_RECVRTHDR);
-    case LINUX_IPV6_RTHDR:
-        return (IPV6_RTHDR);
-    case LINUX_IPV6_RECVDSTOPTS:
-        return (IPV6_RECVDSTOPTS);
-    case LINUX_IPV6_DSTOPTS:
-        return (IPV6_DSTOPTS);
-    case LINUX_IPV6_RECVPATHMTU:
-        return (IPV6_RECVPATHMTU);
-    case LINUX_IPV6_PATHMTU:
-        return (IPV6_PATHMTU);
-    case LINUX_IPV6_DONTFRAG:
-        return (IPV6_DONTFRAG);
-    case LINUX_IPV6_RECVTCLASS:
-        return (IPV6_RECVTCLASS);
-    case LINUX_IPV6_TCLASS:
-        return (IPV6_TCLASS);
+	case LINUX_IPV6_PKTINFO:
+		return (IPV6_PKTINFO);
+	case LINUX_IPV6_RECVHOPLIMIT:
+		return (IPV6_RECVHOPLIMIT);
+	case LINUX_IPV6_HOPLIMIT:
+		return (IPV6_HOPLIMIT);
+	case LINUX_IPV6_RECVHOPOPTS:
+		return (IPV6_RECVHOPOPTS);
+	case LINUX_IPV6_HOPOPTS:
+		return (IPV6_HOPOPTS);
+	case LINUX_IPV6_RTHDRDSTOPTS:
+		return (IPV6_RTHDRDSTOPTS);
+	case LINUX_IPV6_RECVRTHDR:
+		return (IPV6_RECVRTHDR);
+	case LINUX_IPV6_RTHDR:
+		return (IPV6_RTHDR);
+	case LINUX_IPV6_RECVDSTOPTS:
+		return (IPV6_RECVDSTOPTS);
+	case LINUX_IPV6_DSTOPTS:
+		return (IPV6_DSTOPTS);
+	case LINUX_IPV6_RECVPATHMTU:
+		return (IPV6_RECVPATHMTU);
+	case LINUX_IPV6_PATHMTU:
+		return (IPV6_PATHMTU);
+	case LINUX_IPV6_DONTFRAG:
+		return (IPV6_DONTFRAG);
+	case LINUX_IPV6_RECVTCLASS:
+		return (IPV6_RECVTCLASS);
+	case LINUX_IPV6_TCLASS:
+		return (IPV6_TCLASS);
 	}
 	return (-1);
 }
+
+#endif // INET6
 
 
 static int
@@ -585,8 +590,8 @@ linux_to_bsd_cmsg_type(int cmsg_level, int cmsg_type)
 			return cmsg_type;
 		}
 		break;
-	}
 #endif
+	}
 	return (-1);
 }
 
@@ -609,16 +614,22 @@ bsd_to_linux_cmsg_type(int cmsg_level, int cmsg_type)
 		break;
 	case IPPROTO_IP:
 		switch (cmsg_type) {
+		case IP_RECVIF:
+		case IP_RECVDSTADDR:
+			// IP_RECVIF and IP_RECVDSTADDR get combined into IP_PKTINFO
+			return IP_PKTINFO;
 		case IP_PKTINFO:
 			return cmsg_type;
 		}
 		break;
+#ifdef INET6
 	case IPPROTO_IPV6:
 		switch (cmsg_type) {
 		case IPV6_PKTINFO:
 			return cmsg_type;
 		}
 		break;
+#endif
 	}
 
 	return (-1);
@@ -1148,9 +1159,9 @@ linux_sendmsg(int s, struct l_msghdr* linux_msg, int flags, ssize_t* bytes)
 				goto bad;
 
 			cmsg->cmsg_type =
-			    linux_to_bsd_cmsg_type(linux_cmsg->cmsg_level, linux_cmsg->cmsg_type);
+				linux_to_bsd_cmsg_type(linux_cmsg->cmsg_level, linux_cmsg->cmsg_type);
 			cmsg->cmsg_level =
-                            linux_to_bsd_sockopt_level(linux_cmsg->cmsg_level);
+				linux_to_bsd_sockopt_level(linux_cmsg->cmsg_level);
 			if (cmsg->cmsg_type == -1)
 				goto bad;
 
@@ -1246,21 +1257,37 @@ struct linux_recvmsg_args {
 };
 
 int
+linux_recvmsg_append_cmsg(caddr_t buf, socklen_t buflen,
+						  struct l_cmsghdr *linux_cmsg, caddr_t data, socklen_t datalen)
+{
+	int error;
+	caddr_t dst = buf;
+
+	if (LINUX_CMSG_LEN(datalen) > buflen)
+		return EMSGSIZE;
+
+	error = copyout(linux_cmsg, dst, L_CMSG_HDRSZ);
+	if (error)
+		return error;
+	dst += L_CMSG_HDRSZ;
+
+	error = copyout(data, dst, datalen);
+	if (error)
+		return error; 
+
+	return 0;
+}
+
+int
 linux_recvmsg(int s, struct l_msghdr *linux_msg, int flags, ssize_t* bytes)
 {
 	struct cmsghdr *cm;
 	struct msghdr msg;
-	struct l_cmsghdr *linux_cmsg = NULL;
 	socklen_t datalen, outlen;
 	struct mbuf *control = NULL;
 	struct mbuf **controlp = NULL;
-	struct timeval *ftmvl;
-	l_timeval ltmvl;
 	caddr_t outbuf;
 	void *data;
-#if 0
-	int error, i, fd, fds, *fdp;
-#endif
 	int error;
 
 	error = linux_to_bsd_msghdr(&msg, linux_msg);
@@ -1269,12 +1296,12 @@ linux_recvmsg(int s, struct l_msghdr *linux_msg, int flags, ssize_t* bytes)
 
 	/*
 	 * Set msg_flags from flags parameter like sys_recvmsg() for standard behavior.
- 	 * msg_flags in msghdr passed to kern_recvit() are used as in/out.
+	 * msg_flags in msghdr passed to kern_recvit() are used as in/out.
 	 * msg_flags in msghdr passed to recvmsg() are used for out only and the
 	 * flags paramter is used for in.
 	 *
 	 */
-        msg.msg_flags = linux_to_bsd_msg_flags(flags);
+	msg.msg_flags = linux_to_bsd_msg_flags(flags);
 
 	if (msg.msg_name) {
 		error = linux_to_bsd_sockaddr((struct bsd_sockaddr *)msg.msg_name,
@@ -1306,142 +1333,164 @@ linux_recvmsg(int s, struct l_msghdr *linux_msg, int flags, ssize_t* bytes)
 	outbuf = (caddr_t)(linux_msg->msg_control);
 	outlen = 0;
 
-	if (control) {
-		linux_cmsg = (struct l_cmsghdr *)malloc(L_CMSG_HDRSZ, M_TEMP, M_WAITOK | M_ZERO);
+	if (control && outbuf) {
+		struct mbuf *c_mb;
+		uint8_t cmsg_buf[L_CMSG_HDRSZ];
+		struct l_cmsghdr *linux_cmsg = (struct l_cmsghdr *)cmsg_buf;
+		struct in_addr *ipv4_recv_addr = NULL;
+		struct bsd_sockaddr_dl *recv_addr_dl = NULL;
+		struct timeval *ftmvl;
+		l_timeval ltmvl;
 
-		msg.msg_control = mtod(control, struct cmsghdr *);
-		msg.msg_controllen = control->m_hdr.mh_len;
+		for (c_mb = control; c_mb; c_mb = c_mb->m_hdr.mh_next) {
 
-		cm = CMSG_FIRSTHDR(&msg);
+			msg.msg_control = mtod(c_mb, struct cmsghdr *);
+			msg.msg_controllen = c_mb->m_hdr.mh_len;
 
-		while (cm != NULL) {
-			linux_cmsg->cmsg_type =
-			    bsd_to_linux_cmsg_type(cm->cmsg_level, cm->cmsg_type);
-			linux_cmsg->cmsg_level =
-			    bsd_to_linux_sockopt_level(cm->cmsg_level);
-			if (linux_cmsg->cmsg_type == -1) {
-				error = EINVAL;
-				goto bad;
-			}
+			cm = CMSG_FIRSTHDR(&msg);
 
-			data = CMSG_DATA(cm);
-			datalen = (caddr_t)cm + cm->cmsg_len - (caddr_t)data;
+			while (cm != NULL) {
+				linux_cmsg->cmsg_type =
+					bsd_to_linux_cmsg_type(cm->cmsg_level, cm->cmsg_type);
+				linux_cmsg->cmsg_level =
+					bsd_to_linux_sockopt_level(cm->cmsg_level);
+				if (linux_cmsg->cmsg_type == -1) {
+					error = EINVAL;
+					goto bad;
+				}
 
-			if (cm->cmsg_level == SOL_SOCKET) {
-				switch (cm->cmsg_type) {
+				data = CMSG_DATA(cm);
+				datalen = (caddr_t)cm + cm->cmsg_len - (caddr_t)data;
+
+				if (cm->cmsg_level == SOL_SOCKET) {
+					switch (cm->cmsg_type) {
 #if 0
-				case SCM_RIGHTS:
-					if (args->flags & LINUX_MSG_CMSG_CLOEXEC) {
-						fds = datalen / sizeof(int);
-						fdp = data;
-						for (i = 0; i < fds; i++) {
-							fd = *fdp++;
-							(void)kern_fcntl(td, fd,
-							    F_SETFD, FD_CLOEXEC);
+					case SCM_RIGHTS:
+						if (args->flags & LINUX_MSG_CMSG_CLOEXEC) {
+							fds = datalen / sizeof(int);
+							fdp = data;
+							for (i = 0; i < fds; i++) {
+								fd = *fdp++;
+								(void)kern_fcntl(td, fd,
+												 F_SETFD, FD_CLOEXEC);
+							}
 						}
-					}
-					break;
+						break;
 
-				case SCM_CREDS:
-					/*
-					 * Currently LOCAL_CREDS is never in
-					 * effect for Linux so no need to worry
-					 * about sockcred
-					 */
-					if (datalen != sizeof(*cmcred)) {
-						error = EMSGSIZE;
-						goto bad;
-					}
-					cmcred = (struct cmsgcred *)data;
-					bzero(&linux_ucred, sizeof(linux_ucred));
-					linux_ucred.pid = cmcred->cmcred_pid;
-					linux_ucred.uid = cmcred->cmcred_uid;
-					linux_ucred.gid = cmcred->cmcred_gid;
-					data = &linux_ucred;
-					datalen = sizeof(linux_ucred);
-					break;
+					case SCM_CREDS:
+						/*
+						 * Currently LOCAL_CREDS is never in
+						 * effect for Linux so no need to worry
+						 * about sockcred
+						 */
+						if (datalen != sizeof(*cmcred)) {
+							error = EMSGSIZE;
+							goto bad;
+						}
+						cmcred = (struct cmsgcred *)data;
+						bzero(&linux_ucred, sizeof(linux_ucred));
+						linux_ucred.pid = cmcred->cmcred_pid;
+						linux_ucred.uid = cmcred->cmcred_uid;
+						linux_ucred.gid = cmcred->cmcred_gid;
+						data = &linux_ucred;
+						datalen = sizeof(linux_ucred);
+						break;
 #endif
-				case SCM_TIMESTAMP:
-					if (datalen != sizeof(struct timeval)) {
-						error = EMSGSIZE;
+					case SCM_TIMESTAMP:
+						if (datalen != sizeof(struct timeval)) {
+							error = EMSGSIZE;
+							goto bad;
+						}
+						ftmvl = (struct timeval *)data;
+						ltmvl.tv_sec = ftmvl->tv_sec;
+						ltmvl.tv_usec = ftmvl->tv_usec;
+						data = &ltmvl;
+						datalen = sizeof(ltmvl);
+						break;
+					default:
+						error = EINVAL;
 						goto bad;
 					}
-					ftmvl = (struct timeval *)data;
-					ltmvl.tv_sec = ftmvl->tv_sec;
-					ltmvl.tv_usec = ftmvl->tv_usec;
-					data = &ltmvl;
-					datalen = sizeof(ltmvl);
-					break;
-				default:
+				}
+				else if (cm->cmsg_level == IPPROTO_IP) {
+					switch (cm->cmsg_type) {
+					case IP_RECVIF:
+						recv_addr_dl = (struct bsd_sockaddr_dl *) data;
+						goto next;
+					case IP_RECVDSTADDR:
+						ipv4_recv_addr = (struct in_addr *) data;
+						goto next;
+					default:
+						error = EINVAL;
+						goto bad;
+					}
+				}
+#ifdef INET6
+				else if (cm->cmsg_level == IPPROTO_IPV6) {
+					switch (cm->cmsg_type) {
+					case IPV6_PKTINFO:
+						break;
+					default:
+						error = EINVAL;
+						goto bad;
+					}
+				}
+#endif
+				else {
 					error = EINVAL;
 					goto bad;
 				}
-			}
-			else if (cm->cmsg_level == IPPROTO_IP) {
-				switch (cm->cmsg_type) {
-				case IP_PKTINFO:
-					break;
-				default:
-					error = EINVAL;
-					goto bad;
-				}
-			}
-			else if (cm->cmsg_level == IPPROTO_IPV6) {
-				switch (cm->cmsg_type) {
-				case IPV6_PKTINFO:
-					break;
-				default:
-					error = EINVAL;
-					goto bad;
-				}
-			} else {
-				error = EINVAL;
-				goto bad;
-			}
 
-			if (outlen + LINUX_CMSG_LEN(datalen) >
-				linux_msg->msg_controllen) {
-				if (outlen == 0) {
-					error = EMSGSIZE;
+				linux_cmsg->cmsg_len = LINUX_CMSG_LEN(datalen);
+				error = linux_recvmsg_append_cmsg(outbuf, linux_msg->msg_controllen - outlen,
+												  linux_cmsg, (caddr_t)data, datalen);
+				if (error) {
+					if (outlen) {
+						linux_msg->msg_flags |= LINUX_MSG_CTRUNC;
+						error = 0;
+						goto out;
+					}
 					goto bad;
-				} else {
-					linux_msg->msg_flags |=
-						LINUX_MSG_CTRUNC;
+				}
+				outbuf += LINUX_CMSG_ALIGN(datalen);
+				outlen += LINUX_CMSG_LEN(datalen);
+
+next:
+				cm = CMSG_NXTHDR(&msg, cm);
+			}
+		}
+
+		/* FreeBSD doesn't support IP_PKTINFO so build from IP_RECVIF and IP_RECVDSTADDR */
+		if (recv_addr_dl && ipv4_recv_addr) {
+			struct l_in_pktinfo pktinfo;
+			pktinfo.ipi_ifindex = recv_addr_dl->sdl_index;
+			pktinfo.ipi_spec_dst.s_addr = 0;
+			pktinfo.ipi_addr.s_addr = ipv4_recv_addr->s_addr;
+			datalen = sizeof(pktinfo);
+
+			linux_cmsg->cmsg_type = LINUX_IP_PKTINFO;
+			linux_cmsg->cmsg_len = LINUX_CMSG_LEN(datalen);
+			error = linux_recvmsg_append_cmsg(outbuf, linux_msg->msg_controllen - outlen,
+											  linux_cmsg, (caddr_t)&pktinfo, datalen);
+			if (error) {
+				if (outlen) {
+					linux_msg->msg_flags |= LINUX_MSG_CTRUNC;
+					error = 0;
 					goto out;
 				}
+				goto bad;
 			}
-
-			linux_cmsg->cmsg_len = LINUX_CMSG_LEN(datalen);
-			error = copyout(linux_cmsg, outbuf, L_CMSG_HDRSZ);
-			if (error)
-				goto bad;
-			outbuf += L_CMSG_HDRSZ;
-
-			error = copyout(data, outbuf, datalen);
-			if (error)
-				goto bad;
-
 			outbuf += LINUX_CMSG_ALIGN(datalen);
 			outlen += LINUX_CMSG_LEN(datalen);
-
-			cm = CMSG_NXTHDR(&msg, cm);
 		}
 	}
 
 out:
 	linux_msg->msg_controllen = outlen;
-#if 0
-	error = copyout(linux_msg, &msg), sizeof(linux_msg));
-#endif
 
 bad:
-#if 0
-	free(iov);
-#endif
 	if (control != NULL)
 		m_freem(control);
-	if (linux_cmsg != NULL)
-		free(linux_cmsg);
 
 	return (error);
 }
@@ -1477,6 +1526,35 @@ int linux_to_bsd_tcp_sockopt(int name)
 }
 
 int
+linux_setsockopt_ip_pktinfo(int s, caddr_t val, int valsize)
+{
+	int error;
+
+	if ((error = sys_setsockopt(s, IPPROTO_IP, IP_RECVIF, val, valsize)))
+		return error;
+	return sys_setsockopt(s, IPPROTO_IP, IP_RECVDSTADDR, val, valsize);
+}
+
+int
+linux_getsockopt_ip_pktinfo(int s, void *val, socklen_t *valsize)
+{
+	int error;
+	int if_enable = 0, addr_enable = 0;
+	socklen_t optsize = sizeof(addr_enable);
+
+	if (*valsize < sizeof(addr_enable)) {
+		errno = EINVAL;
+		return -1;
+	}
+	if ((error = sys_getsockopt(s, IPPROTO_IP, IP_RECVIF, &if_enable, &optsize)))
+		return error;
+	if ((error = sys_getsockopt(s, IPPROTO_IP, IP_RECVDSTADDR, &addr_enable, &optsize)))
+		return error;
+	*(int *) val = (if_enable && addr_enable);
+	return 0;
+}
+
+int
 linux_setsockopt(int s, int level, int name, caddr_t val, int valsize)
 {
 	int error;
@@ -1486,6 +1564,9 @@ linux_setsockopt(int s, int level, int name, caddr_t val, int valsize)
 		name = linux_to_bsd_so_sockopt(name);
 		break;
 	case IPPROTO_IP:
+		if (name == LINUX_IP_PKTINFO) {
+			return linux_setsockopt_ip_pktinfo(s, val, valsize);
+		}
 		name = linux_to_bsd_ip_sockopt(name);
 		break;
 #ifdef INET6
@@ -1527,6 +1608,9 @@ linux_getsockopt(int s, int level, int name, void *val, socklen_t *valsize)
 		name = linux_to_bsd_so_sockopt(name);
 		break;
 	case IPPROTO_IP:
+		if (name == LINUX_IP_PKTINFO) {
+			return linux_getsockopt_ip_pktinfo(s, val, valsize);
+		}
 		name = linux_to_bsd_ip_sockopt(name);
 		break;
 #ifdef INET6

--- a/bsd/sys/compat/linux/linux_socket.h
+++ b/bsd/sys/compat/linux/linux_socket.h
@@ -116,7 +116,7 @@ struct l_cmsghdr {
 #define	LINUX_AF_APPLETALK	5
 #define	LINUX_AF_INET6		10
 #define LINUX_AF_NETLINK	16
-#define LINUX_AF_PACKET     17
+#define LINUX_AF_PACKET		17
 
 /* Supported socket types */
 
@@ -141,11 +141,25 @@ struct l_ucred {
 	uint32_t	gid;
 };
 
+struct l_in_addr {
+	uint32_t	s_addr;
+};
+
+struct l_in_pktinfo {
+	l_uint			ipi_ifindex;
+	struct l_in_addr	ipi_spec_dst;
+	struct l_in_addr	ipi_addr;
+};
+
 /* Socket options */
 #define	LINUX_IP_TOS		1
 #define	LINUX_IP_TTL		2
 #define	LINUX_IP_HDRINCL	3
 #define	LINUX_IP_OPTIONS	4
+#define LINUX_IP_ROUTER_ALERT	5
+#define LINUX_IP_RECVOPTS	6
+#define LINUX_IP_RETOPTS	7
+#define LINUX_IP_PKTINFO	8
 
 #define	LINUX_IP_MULTICAST_IF		32
 #define	LINUX_IP_MULTICAST_TTL		33

--- a/bsd/sys/netinet/tcp_input.cc
+++ b/bsd/sys/netinet/tcp_input.cc
@@ -722,12 +722,16 @@ findpcb:
 	}
 #endif
 
+#ifdef INET6
 	if (isipv6) {
 		inp = in6_pcblookup_mbuf(&V_tcbinfo, &ip6->ip6_src,
 			th->th_sport, &ip6->ip6_dst, th->th_dport,
 			INPLOOKUP_WILDCARD | INPLOOKUP_LOCKPCB,
 			m->M_dat.MH.MH_pkthdr.rcvif, m);
-	} else {
+	}
+	else
+#endif
+	{
 		inp = in_pcblookup_mbuf(&V_tcbinfo, ip->ip_src,
 			th->th_sport, ip->ip_dst, th->th_dport,
 			INPLOOKUP_WILDCARD | INPLOOKUP_LOCKPCB,

--- a/bsd/sys/netinet6/nd6.cc
+++ b/bsd/sys/netinet6/nd6.cc
@@ -157,6 +157,8 @@ nd6_init(void)
 	/* initialization of the default router list */
 	TAILQ_INIT(&V_nd_defrouter);
 
+	nd6_dad_init();
+
 	/* start timer */
 	/* TODO: Verify this callout is MPSAFE
          *       nd6_slowtimo() iterates trhough V_ifnet list holding the IFNET_RLOCK

--- a/bsd/sys/netinet6/nd6.h
+++ b/bsd/sys/netinet6/nd6.h
@@ -429,6 +429,7 @@ void nd6_ns_input(struct mbuf *, int, int);
 void nd6_ns_output(struct ifnet *, const struct in6_addr *,
 	const struct in6_addr *, struct llentry *, int);
 caddr_t nd6_ifptomac(struct ifnet *);
+void nd6_dad_init(void);
 void nd6_dad_start(struct bsd_ifaddr *, int);
 void nd6_dad_stop(struct bsd_ifaddr *);
 void nd6_dad_duplicated(struct bsd_ifaddr *);

--- a/conf/base.mk
+++ b/conf/base.mk
@@ -9,3 +9,8 @@ conf-logger_debug=0
 # This macro controls the NDEBUG macro that is used to identify the debug
 # build variant in the code.
 conf-DEBUG_BUILD=0
+
+# Set to 1 to enable IPV6
+# This macro controls the FreeBSD INET6 macro defined in bsd/porting/netport.h
+conf-INET6=1
+

--- a/modules/tests/Makefile
+++ b/modules/tests/Makefile
@@ -21,6 +21,13 @@ makedir = $(call very-quiet, mkdir -p $(dir $@))
 
 autodepend = -MD -MT $@ -MP
 
+include $(OSV_BASE)/conf/base.mk
+
+configuration-defines = conf-preempt conf-debug_memory conf-logger_debug conf-INET6
+configuration = $(foreach cf,$(configuration-defines), \
+                      -D$(cf:conf-%=CONF_%)=$($(cf)))
+
+
 INCLUDES = -I$(src)/arch/$(ARCH) -I$(src) -I$(src)/include \
 	-I$(src)/arch/common -isystem $(src)/include/glibc-compat \
 	$(shell $(CXX) -E -xc++ - -v </dev/null 2>&1 | awk '/^End/ {exit} /^ .*c\+\+/ {print "-isystem" $$0}') \
@@ -28,7 +35,7 @@ INCLUDES = -I$(src)/arch/$(ARCH) -I$(src) -I$(src)/include \
 	-isystem $(out)/gen/include
 
 COMMON = $(autodepend) $(INCLUDES) -g -O2 -fPIC -DBOOST_TEST_DYN_LINK \
-	-U _FORTIFY_SOURCE -D_KERNEL -D__OSV__ -DCONF_debug_memory=0 \
+	-U _FORTIFY_SOURCE -D_KERNEL -D__OSV__ $(configuration) \
 	-Wall -Wno-pointer-arith -Wformat=0 -Wno-format-security
 
 LIBS =
@@ -87,7 +94,8 @@ tests := tst-pthread.so misc-ramdisk.so tst-vblk.so tst-bsd-evh.so \
 	tst-ifaddrs.so tst-pthread-affinity-inherit.so tst-sem-timed-wait.so \
 	tst-ttyname.so tst-pthread-barrier.so tst-feexcept.so tst-math.so \
 	tst-sigaltstack.so tst-fread.so tst-tcp-cork.so \
-	tst-calloc.so tst-crypt.so tst-posix-aio.so
+	tst-calloc.so tst-crypt.so tst-posix-aio.so \
+	tst-socket-timestamp.so tst-pktinfo.so
 
 #	libstatic-thread-variable.so tst-static-thread-variable.so \
 

--- a/tests/tst-pktinfo.cc
+++ b/tests/tst-pktinfo.cc
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2014 Cloudius Systems, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+// To compile on Linux, use: g++ -g -pthread -std=c++11 tests/tst-uio.cc
+
+// This test tests the SO_TIMESTMAP socket option.
+
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <sys/uio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <arpa/inet.h>
+
+#include <iostream>
+#include <thread>
+#include <vector>
+#include <mutex>
+
+#ifdef __OSV__
+#include <bsd/porting/netport.h> // Get INET6
+#else
+#define INET6
+#endif
+
+
+// Multiple threads can call expect functions at the same time
+// so need to protect against concurrent writes to cout.
+std::mutex test_mutex; 
+
+static int tests = 0, fails = 0;
+
+template<typename T>
+bool do_expect(T actual, T expected, const char *actuals, const char *expecteds, const char *file, int line)
+{
+    std::lock_guard<std::mutex> lock(test_mutex);
+
+    ++tests;
+    if (actual != expected) {
+        fails++;
+        std::cout << "FAIL: " << file << ":" << line << ": For " << actuals
+                << " expected " << expecteds << "(" << expected << "), saw "
+                << actual << ".\n";
+        return false;
+    }
+    std::cout << "OK: " << file << ":" << line << ".\n";
+    return true;
+}
+template<typename T>
+bool do_expectge(T actual, T expected, const char *actuals, const char *expecteds, const char *file, int line)
+{
+    std::lock_guard<std::mutex> lock(test_mutex);
+
+    ++tests;
+    if (actual < expected) {
+        fails++;
+        std::cout << "FAIL: " << file << ":" << line << ": For " << actuals
+                << " expected >=" << expecteds << ", saw " << actual << ".\n";
+        return false;
+    }
+    std::cout << "OK: " << file << ":" << line << ".\n";
+    return true;
+}
+#define expect(actual, expected) do_expect(actual, expected, #actual, #expected, __FILE__, __LINE__)
+#define expectge(actual, expected) do_expectge(actual, expected, #actual, #expected, __FILE__, __LINE__)
+#define expect_errno(call, experrno) ( \
+        do_expect((long)(call), (long)-1, #call, "-1", __FILE__, __LINE__) && \
+        do_expect(errno, experrno, #call " errno",  #experrno, __FILE__, __LINE__) )
+#define expect_success(var, call) \
+        errno = 0; \
+        var = call; \
+        do_expectge(var, 0, #call, "0", __FILE__, __LINE__); \
+        do_expect(errno, 0, #call " errno",  "0", __FILE__, __LINE__);
+
+void test_ipv4()
+{
+    int sockfd;
+    int optval = 1;
+    struct sockaddr_in serveraddr;
+    socklen_t serveraddr_len = sizeof(serveraddr);
+    const int npacket = 5;
+    int ret;
+
+    expect_success(sockfd, socket(AF_INET, SOCK_DGRAM, 0));
+    expect_success(ret, setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)));
+    expect_success(ret, setsockopt(sockfd, IPPROTO_IP, IP_PKTINFO, &optval, sizeof(optval)));
+
+    bzero(&serveraddr, sizeof(serveraddr));
+    serveraddr.sin_family = AF_INET;
+    serveraddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    serveraddr.sin_port = 0; // Find next available port
+    expect_success(ret, bind(sockfd, (struct sockaddr*) &serveraddr, serveraddr_len));
+
+    expect_success(ret, getsockname(sockfd, (struct sockaddr*) &serveraddr, &serveraddr_len));
+    expect(serveraddr.sin_family, (in_port_t)AF_INET);
+    std::cout << "Server bound to UDP port " << ntohs(serveraddr.sin_port) << std::endl;
+
+    std::thread t([sockfd, npacket] {
+        struct msghdr msg;
+        struct iovec iov;
+        uint8_t buf[64];
+        uint8_t controlbuf[CMSG_SPACE(sizeof(struct in_pktinfo))];
+
+        bzero(&msg, sizeof(msg));
+        bzero(&iov, sizeof(iov));
+        for (int ipacket = 0; ipacket < npacket; ++ipacket) {
+            iov.iov_base = buf;
+            iov.iov_len = sizeof(buf);
+            msg.msg_iov = &iov;
+            msg.msg_iovlen = 1;
+            msg.msg_control = controlbuf;
+            msg.msg_controllen = sizeof(controlbuf);
+
+            int n;
+            expect_success(n, recvmsg(sockfd, &msg, 0));
+            expect(n, 6);
+
+            struct in_pktinfo pktinfo;
+            bool pktinfo_valid = false;
+
+            for (auto cmptr = CMSG_FIRSTHDR(&msg); cmptr != NULL; cmptr = CMSG_NXTHDR(&msg, cmptr)) {
+                if ((cmptr->cmsg_level == IPPROTO_IP) && (cmptr->cmsg_type == IP_PKTINFO)) {
+                    memcpy(&pktinfo, CMSG_DATA(cmptr), sizeof(pktinfo));
+                    pktinfo_valid = true;
+                    break;
+                }
+            }
+
+            expect(pktinfo_valid, true);
+
+            char ipaddr[INET_ADDRSTRLEN]; 
+            inet_ntop(AF_INET, &pktinfo.ipi_addr, ipaddr, sizeof(ipaddr));
+            std::cout << "ifindex " << pktinfo.ipi_ifindex << " ipaddr " << ipaddr << std::endl;
+            expect(pktinfo.ipi_addr.s_addr, htonl(INADDR_LOOPBACK));
+        }
+    });
+
+    int sendsock;
+
+    expect_success(sendsock, socket(AF_INET, SOCK_DGRAM, 0));
+    for (int ipacket = 0; ipacket < npacket; ++ipacket) {
+        expect_success(ret, sendto(sendsock, "Hello!", 6, 0, (const sockaddr*) &serveraddr, sizeof(serveraddr)));
+    }
+    t.join();
+    close(sockfd);
+    close(sendsock);
+}
+
+#ifdef INET6
+
+void test_ipv6()
+{
+    int sockfd;
+    int optval = 1;
+    struct sockaddr_in6 serveraddr;
+    socklen_t serveraddr_len = sizeof(serveraddr);
+    const int npacket = 5;
+    int ret;
+
+    expect_success(sockfd, socket(AF_INET6, SOCK_DGRAM, 0));
+    expect_success(ret, setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)));
+    expect_success(ret, setsockopt(sockfd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &optval, sizeof(optval)));
+
+    bzero(&serveraddr, sizeof(serveraddr));
+    serveraddr.sin6_family = AF_INET6;
+    serveraddr.sin6_addr = in6addr_loopback;
+    serveraddr.sin6_port = 0; // Find next available port
+    expect_success(ret, bind(sockfd, (struct sockaddr*) &serveraddr, serveraddr_len));
+
+    expect_success(ret, getsockname(sockfd, (struct sockaddr*) &serveraddr, &serveraddr_len));
+    expect(serveraddr.sin6_family, (in_port_t)AF_INET6);
+    std::cout << "Server bound to UDP port " << ntohs(serveraddr.sin6_port) << std::endl;
+
+    std::thread t([sockfd, npacket] {
+        struct msghdr msg;
+        struct iovec iov;
+        uint8_t buf[64];
+        uint8_t controlbuf[CMSG_SPACE(sizeof(struct in6_pktinfo))];
+
+        bzero(&msg, sizeof(msg));
+        bzero(&iov, sizeof(iov));
+        for (int ipacket = 0; ipacket < npacket; ++ipacket) {
+            iov.iov_base = buf;
+            iov.iov_len = sizeof(buf);
+            msg.msg_iov = &iov;
+            msg.msg_iovlen = 1;
+            msg.msg_control = controlbuf;
+            msg.msg_controllen = sizeof(controlbuf);
+
+            int n;
+            expect_success(n, recvmsg(sockfd, &msg, 0));
+            expect(n, 6);
+
+            struct in6_pktinfo pktinfo;
+            bool pktinfo_valid = false;
+
+            for (auto cmptr = CMSG_FIRSTHDR(&msg); cmptr != NULL; cmptr = CMSG_NXTHDR(&msg, cmptr)) {
+                if ((cmptr->cmsg_level == IPPROTO_IPV6) && (cmptr->cmsg_type == IPV6_PKTINFO)) {
+                    memcpy(&pktinfo, CMSG_DATA(cmptr), sizeof(pktinfo));
+                    pktinfo_valid = true;
+                    break;
+                }
+            }
+
+            expect(pktinfo_valid, true);
+
+            char ipaddr[INET6_ADDRSTRLEN]; 
+            inet_ntop(AF_INET6, &pktinfo.ipi6_addr, ipaddr, sizeof(ipaddr));
+            std::cout << "ifindex " << pktinfo.ipi6_ifindex << " ipaddr " << ipaddr << std::endl;
+            expect(std::string(ipaddr), std::string("::1"));
+        }
+    });
+
+    int sendsock;
+
+    expect_success(sendsock, socket(AF_INET6, SOCK_DGRAM, 0));
+    for (int ipacket = 0; ipacket < npacket; ++ipacket) {
+        expect_success(ret, sendto(sendsock, "Hello!", 6, 0, (const sockaddr*) &serveraddr, sizeof(serveraddr)));
+    }
+    t.join();
+    close(sockfd);
+    close(sendsock);
+}
+
+#endif
+
+int main()
+{
+    test_ipv4();
+#ifdef INET6
+    test_ipv6();
+#endif
+    std::cout << "SUMMARY: " << tests << " tests, " << fails << " failures\n";
+    return fails == 0 ? 0 : 1;
+}
+

--- a/tests/tst-socket-timestamp.cc
+++ b/tests/tst-socket-timestamp.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2014 Cloudius Systems, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+// To compile on Linux, use: g++ -g -pthread -std=c++11 tests/tst-uio.cc
+
+// This test tests the SO_TIMESTMAP socket option.
+
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <sys/uio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <arpa/inet.h>
+
+#include <iostream>
+#include <thread>
+#include <vector>
+#include <mutex>
+
+// Multiple threads can call expect functions at the same time
+// so need to protect against concurrent writes to cout.
+std::mutex test_mutex; 
+
+static int tests = 0, fails = 0;
+
+template<typename T>
+bool do_expect(T actual, T expected, const char *actuals, const char *expecteds, const char *file, int line)
+{
+    std::lock_guard<std::mutex> lock(test_mutex);
+
+    ++tests;
+    if (actual != expected) {
+        fails++;
+        std::cout << "FAIL: " << file << ":" << line << ": For " << actuals
+                << " expected " << expecteds << "(" << expected << "), saw "
+                << actual << ".\n";
+        return false;
+    }
+    std::cout << "OK: " << file << ":" << line << ".\n";
+    return true;
+}
+template<typename T>
+bool do_expectge(T actual, T expected, const char *actuals, const char *expecteds, const char *file, int line)
+{
+    std::lock_guard<std::mutex> lock(test_mutex);
+
+    ++tests;
+    if (actual < expected) {
+        fails++;
+        std::cout << "FAIL: " << file << ":" << line << ": For " << actuals
+                << " expected >=" << expecteds << ", saw " << actual << ".\n";
+        return false;
+    }
+    std::cout << "OK: " << file << ":" << line << ".\n";
+    return true;
+}
+#define expect(actual, expected) do_expect(actual, expected, #actual, #expected, __FILE__, __LINE__)
+#define expectge(actual, expected) do_expectge(actual, expected, #actual, #expected, __FILE__, __LINE__)
+#define expect_errno(call, experrno) ( \
+        do_expect((long)(call), (long)-1, #call, "-1", __FILE__, __LINE__) && \
+        do_expect(errno, experrno, #call " errno",  #experrno, __FILE__, __LINE__) )
+#define expect_success(var, call) \
+        errno = 0; \
+        var = call; \
+        do_expectge(var, 0, #call, "0", __FILE__, __LINE__); \
+        do_expect(errno, 0, #call " errno",  "0", __FILE__, __LINE__);
+
+int main()
+{
+    int sockfd;
+    int optval = 1;
+    struct sockaddr_in serveraddr;
+    socklen_t serveraddr_len = sizeof(serveraddr);
+    const int npacket = 5;
+    int ret;
+
+    expect_success(sockfd, socket(AF_INET, SOCK_DGRAM, 0));
+    expect(setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)), 0);
+    expect(setsockopt(sockfd, SOL_SOCKET, SO_TIMESTAMP, &optval, sizeof(optval)), 0);
+
+    bzero(&serveraddr, sizeof(serveraddr));
+    serveraddr.sin_family = AF_INET;
+    serveraddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    serveraddr.sin_port = 0; // Find next available port
+    expect_success(ret, bind(sockfd, (struct sockaddr*) &serveraddr, serveraddr_len));
+
+    expect_success(ret, getsockname(sockfd, (struct sockaddr*) &serveraddr, &serveraddr_len));
+    expect(serveraddr.sin_family, (in_port_t)AF_INET);
+    std::cout << "Server bound to UDP port " << ntohs(serveraddr.sin_port) << std::endl;
+
+    std::thread t([sockfd, npacket] {
+        struct msghdr msg;
+        struct iovec iov;
+        uint8_t buf[64];
+        uint8_t controlbuf[CMSG_SPACE(sizeof(struct timeval))];
+        struct timeval start, end;
+        std::vector<struct timeval> timestamps;
+
+        gettimeofday(&start, NULL);
+
+        bzero(&msg, sizeof(msg));
+        bzero(&iov, sizeof(iov));
+        for (int ipacket = 0; ipacket < npacket; ++ipacket) {
+            iov.iov_base = buf;
+            iov.iov_len = sizeof(buf);
+            msg.msg_iov = &iov;
+            msg.msg_iovlen = 1;
+            msg.msg_control = controlbuf;
+            msg.msg_controllen = sizeof(controlbuf);
+
+            int n;
+            expect_success(n, recvmsg(sockfd, &msg, 0));
+            expect(n, 6);
+
+            // Extract receive timestamp from cmsg data
+            for (auto cmptr = CMSG_FIRSTHDR(&msg); cmptr != NULL; cmptr = CMSG_NXTHDR(&msg, cmptr)) {
+                if ((cmptr->cmsg_level == SOL_SOCKET) && (cmptr->cmsg_type == SCM_TIMESTAMP)) {
+                    struct timeval tv;
+                    memcpy(&tv, CMSG_DATA(cmptr), sizeof(tv));
+                    timestamps.push_back(tv);
+                }
+            }
+        }
+
+        gettimeofday(&end, NULL);
+
+        // Validate received timestamps
+        expect(timestamps.size(), (std::size_t)5);
+        const struct timeval *prev_tv = NULL;
+        for (auto const & tv : timestamps) {
+            expect(timercmp(&tv, &start, >=), true);
+            expect(timercmp(&tv, &end, <=), true);
+            if (prev_tv) {
+               expect(timercmp(&tv, prev_tv, >=), true);
+            }
+            prev_tv = &tv;
+        }
+    });
+
+    int sendsock;
+
+    expect_success(sendsock, socket(AF_INET, SOCK_DGRAM, 0));
+    for (int ipacket = 0; ipacket < npacket; ++ipacket) {
+        expect_success(ret, sendto(sendsock, "Hello!", 6, 0, (const sockaddr*) &serveraddr, sizeof(serveraddr)));
+    }
+    t.join();
+    close(sockfd);
+    close(sendsock);
+
+    std::cout << "SUMMARY: " << tests << " tests, " << fails << " failures\n";
+    return fails == 0 ? 0 : 1;
+}
+

--- a/tests/tst-tcp-v6.cc
+++ b/tests/tst-tcp-v6.cc
@@ -20,9 +20,13 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/interprocess/sync/interprocess_semaphore.hpp>
 
-#define HAS_INET6
+#ifdef __OSV__
+#include <bsd/porting/netport.h> // Get INET6 
+#else
+#define INET6
+#endif
 
-#ifndef HAS_INET6
+#ifndef INET6
 
 /*
  * This is a test for OSv's IPv6 non-support :-) Although we do not support
@@ -238,5 +242,5 @@ BOOST_AUTO_TEST_CASE(test_ipv6_clients_are_not_reset_when_backlog_is_full_and_th
     close(listen_s);
 }
 
-#endif
+#endif /* INET6 */
 


### PR DESCRIPTION
OSv callouts don't support non-MPSAFE mode.

There are still 2 more IPv6 NDP callouts which are not MPSAFE, but those are a bit more complicated to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/osv/4)
<!-- Reviewable:end -->
