### PR TITLE
cloud-init: Added support for static IP in cloud-init ISO

### DIFF
--- a/arch/aarch64/firmware.cc
+++ b/arch/aarch64/firmware.cc
@@ -18,4 +18,15 @@ std::string firmware_vendor()
     return "Unknown";
 }
 
+std::string system_manufacturer()
+{
+    return "Unknown";
+}
+
+std::string system_product_name()
+{
+    return "Unknown";
+}
+
+
 }

--- a/arch/x64/dmi.cc
+++ b/arch/x64/dmi.cc
@@ -12,6 +12,8 @@
 #include <string.h>
 
 std::string dmi_bios_vendor("Unknown");
+std::string dmi_system_manufacturer("Unknown");
+std::string dmi_system_product_name("Unknown");
 
 static inline u8 read_u8(const char* buf, unsigned long idx)
 {
@@ -80,6 +82,12 @@ static void dmi_table(u32 base, u16 len, u16 num)
         case 0: /* 7.1. BIOS Information */
             if (header.length >= 18) {
                 dmi_bios_vendor = dmi_string(header, header.data[0x04]);
+            }
+            break;
+        case 1: /* 7.2. System Information */
+            if (header.length >= 8) {
+                dmi_system_manufacturer = dmi_string(header, header.data[0x04]);
+                dmi_system_product_name = dmi_string(header, header.data[0x05]);
             }
             break;
         default:

--- a/arch/x64/dmi.hh
+++ b/arch/x64/dmi.hh
@@ -11,6 +11,8 @@
 #include <string>
 
 extern std::string dmi_bios_vendor;
+extern std::string dmi_system_manufacturer;
+extern std::string dmi_system_product_name;
 
 void dmi_probe();
 

--- a/arch/x64/firmware.cc
+++ b/arch/x64/firmware.cc
@@ -21,4 +21,14 @@ std::string firmware_vendor()
     return dmi_bios_vendor;
 }
 
+std::string system_manufacturer()
+{
+    return dmi_system_manufacturer;
+}
+
+std::string system_product_name()
+{
+    return dmi_system_product_name;
+}
+
 }

--- a/include/osv/firmware.hh
+++ b/include/osv/firmware.hh
@@ -16,6 +16,10 @@ void firmware_probe();
 
 std::string firmware_vendor();
 
+std::string system_manufacturer();
+
+std::string system_product_name();
+
 }
 
 #endif

--- a/modules/cloud-init/cloud-init.cc
+++ b/modules/cloud-init/cloud-init.cc
@@ -11,6 +11,7 @@
 #include <memory>
 #include "client.hh"
 #include <boost/asio.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include "data-source.hh"
 #include <osv/debug.hh>
@@ -283,9 +284,13 @@ void osvinit::load_url(const std::string& server, const std::string& path,
 
 void osvinit::load_from_cloud(bool ignore_missing_source)
 {
+    fprintf(stderr, "Firmware vendor: %s\n", osv::firmware_vendor().c_str());
+    fprintf(stderr, "System manufacturer: %s\n", osv::system_manufacturer().c_str());
+
     if (!_force_probe
         && osv::hypervisor() != osv::hypervisor_type::xen
         && osv::firmware_vendor() != "Google"
+        && !boost::starts_with(osv::system_manufacturer(), "OpenStack")
         && osv::hypervisor() != osv::hypervisor_type::vmware_esxi) {
         return;
     }

--- a/modules/cloud-init/cmdline
+++ b/modules/cloud-init/cmdline
@@ -1,1 +1,1 @@
-/usr/mgmt/cloud-init.so;
+/usr/mgmt/cloud-init.so --cloud;

--- a/modules/cloud-init/cmdline-local
+++ b/modules/cloud-init/cmdline-local
@@ -1,0 +1,1 @@
+/usr/mgmt/cloud-init.so --disk;

--- a/modules/cloud-init/main.cc
+++ b/modules/cloud-init/main.cc
@@ -114,6 +114,8 @@ int main(int argc, char* argv[])
             ("help", "produce help message")
             ("skip-error", "do not stop on error")
             ("force-probe", "force data source probing")
+            ("cloud", "check cloud data sources")
+            ("disk", "check local disk data sources")
             ("file", po::value<std::string>(), "an init file")
             ("server", po::value<std::string>(), "a server to read the file from. must come with a --url")
             ("url", po::value<std::string>(), "a url at the server")
@@ -147,9 +149,9 @@ int main(int argc, char* argv[])
             init.load_url(config["server"].as<std::string>(),
                 config["url"].as<std::string>(),
                 config["port"].as<std::string>());
-        } else if(config_disk("/tmp/config.yaml")) {
+        } else if (config.count("disk") > 0 && config_disk("/tmp/config.yaml")) {
             init.load_file("/tmp/config.yaml");
-        } else {
+        } else if (config.count("cloud") > 0) {
             init.load_from_cloud();
         }
 

--- a/modules/cloud-init/module.py
+++ b/modules/cloud-init/module.py
@@ -8,7 +8,8 @@ _module = '${OSV_BASE}/modules/cloud-init'
 usr_files = FileMap()
 usr_files.add(os.path.join(_module, 'cloud-init.so')).to('/usr/mgmt/cloud-init.so')
 usr_files.add(os.path.join(_module, 'cloud-init.yaml')).to('/usr/mgmt/cloud-init.yaml')
-usr_files.add(os.path.join(_module, 'cmdline')).to('/init/00-cmdline')
+usr_files.add(os.path.join(_module, 'cmdline')).to('/init/00-cloud-init')
+usr_files.add(os.path.join(_module, 'cmdline-local')).to('/init/local/00-cloud-init')
 
 api.require('httpserver')
 api.require('libyaml')

--- a/modules/cloud-init/network-module.cc
+++ b/modules/cloud-init/network-module.cc
@@ -246,14 +246,18 @@ void network_module::configure_physical_interface(const YAML::Node& node, networ
                 }
 
                 // Add address to interface
-                if (osv::if_add_addr(if_name, address, netmask) != 0){
+                if (osv::if_add_addr(if_name, address, netmask) != 0) {
                     debug("cloud-init: %s error.  Failed adding address %s/%s to interface %s\n",
                           __FUNCTION__,
                           address.c_str(), netmask.c_str(), if_name.c_str());
                     continue;
                 }
+
+                // Set environment variable telling loader not to start DHCP
+                setenv("USE_STATIC_IP", "True", 1);
+
                 if (subnet["gateway"]) {
-                    std::string gateway = node["gateway"].as<std::string>();
+                    std::string gateway = subnet["gateway"].as<std::string>();
                     std::string network = ipv6 ? "::" : "0.0.0.0";
                     std::string netmask = ipv6 ? "::" : "0.0.0.0";
 


### PR DESCRIPTION
The OSv loader was modified so that it does the following:
1. Runs commands from the /init/local directory.
2. Start DHCP if the USE_STATIC_IP environment variable was not set.
3. Runs the rest of the commands in the /init directory.

This allows cloud-init run in /init/local to disable running DHCP
and prevent blocking waiting for DHCP to bind.

OpenStack platform detection using DMI System inforation was also
added so that OpenStack network data sources will be checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/osv/8)
<!-- Reviewable:end -->
